### PR TITLE
Update Podfile to remove the Swift 3.0 requirement

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,10 +1,1 @@
 pod 'TTRangeSlider', '~> 1.0.6'
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        if target.name == 'TTRangeSlider'
-            target.build_configurations.each do |config|
-                config.build_settings['SWIFT_VERSION'] = '3.0'
-            end
-        end
-    end
-end


### PR DESCRIPTION
I have tested building your plugin including this modification and it will build fine on XCode Version 10.2.1 (10E1001).  v10.2.1 is the latest and requires Swift 4.0+.  Please let me know if you have any questions.

Closes #7 